### PR TITLE
Need to be explicit about the date when instatiating the objects

### DIFF
--- a/index.php
+++ b/index.php
@@ -7,9 +7,10 @@ use Citco\Carbon as CitcoCarbon;
 use CarbonExt\FiscalYear\Calculator;
 
 // Object Instantiation
-$brisbane = Carbon::today('Australia/Brisbane');
-$newYorkCity = Carbon::today('America/New_York');
-$dtBerlin = Carbon::today('Europe/Berlin');
+
+$brisbane = new Carbon('2015-12-01', 'Australia/Brisbane');
+$newYorkCity  = new Carbon('2015-12-01', 'America/New_York');
+$dtBerlin = new Carbon('2015-12-01', 'Europe/Berlin');
 
 $outputString = "Time difference between %s & %s: %s hours.\n";
 


### PR DESCRIPTION
The `today()` method isn't a reliable method here because it's somehow tied to the timezone where the script ran. Need to explicitly set midnight on a specific day to get the right time differences.
